### PR TITLE
pkg templates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ kwargs = {
     ],
     "packages": ["sensorml2iso"],
     "package_data": {
-        "templates": [
-            "*.xml"
+        "sensorml2iso": [
+            "templates/*.xml"
         ]
     },
     "version": "1.0.2",


### PR DESCRIPTION
The `template` xml files did not make into the final folder.

Closes #17 