### PR TITLE
Pin pyoos api 083

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ### sensorml2iso ###
 
+[![Build Status](https://travis-ci.org/ioos/sensorml2iso.svg?branch=master)](https://travis-ci.org/ioos/sensorml2iso)
+
 A simple Python module to query an IOOS SOS service for active sensors and
 output ISO 19115-2-compliant xml metadata following a template.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ jinja2
 lxml
 numpy
 pandas
-pyoos
+pyoos >=0.8.3
 shapely


### PR DESCRIPTION
@mwengren this adds the pin to ensure only `pyoos >= 0.8.3` API is used.
Also, I added the Travis-CI badge to make it easier to inspect the tests results, which are failing at the moment, see https://travis-ci.org/ioos/sensorml2iso/builds/224240736