### PR TITLE
Fix sensorml2iso.py utc_code assignment

### DIFF
--- a/sensorml2iso/sensorml2iso.py
+++ b/sensorml2iso/sensorml2iso.py
@@ -421,7 +421,7 @@ class Sensorml2Iso:
 
             # calculate event_time using self.getobs_req_hours:
             event_time_formatstr = "{begin:%Y-%m-%dT%H:%M:%S}{utc_code}/{end:%Y-%m-%dT%H:%M:%S}{utc_code}"
-            utc_code = 'Z' if self.sos_type.lower() == 'ndbc' else None
+            utc_code = 'Z' if self.sos_type.lower() == 'ndbc' else ''
             if station['starting'] is not None and station['ending'] is not None:
                 event_time = event_time_formatstr.format(
                     begin=station['ending'] - timedelta(hours=self.getobs_req_hours), end=station['ending'],


### PR DESCRIPTION
Corrected utc_code assignment in `get_stations_df()`, line 424, for `self.sos_type.lower() != 'ndbc'`. Set to blank character rather than None, because the string "None" was incorrectly being inserted into the eventTime string.